### PR TITLE
Remove dummy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml-networks"
-version = "0.2.3"
+version = "0.2.4"
 description = "A unified deep learning model building library for PyTorch and JAX with shared dataclass-based configuration"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/ml_networks/jax/__init__.py
+++ b/src/ml_networks/jax/__init__.py
@@ -1,5 +1,5 @@
 from .activations import Activation, CRReLU, REReLU, SiGLU, TanhExp
-from .base import BaseModule
+from .base import BaseModule, JaxLightningModule
 from .contrastive import ContrastiveLearningLoss
 from .distributions import (
     BernoulliStoch,
@@ -14,6 +14,7 @@ from .distributions import (
 )
 from .hypernetworks import HyperNet
 from .jax_utils import (
+    JaxModelCheckpoint,
     JaxModelSummary,
     JaxTrainer,
     MinMaxNormalize,
@@ -67,6 +68,8 @@ __all__ = [
     "Encoder",
     "FocalFrequencyLoss",
     "HyperNet",
+    "JaxLightningModule",
+    "JaxModelCheckpoint",
     "JaxModelSummary",
     "JaxTrainer",
     "LinearNormActivation",

--- a/src/ml_networks/jax/base.py
+++ b/src/ml_networks/jax/base.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytorch_lightning as pl
-import torch
 from flax import nnx
 
 
@@ -86,23 +86,23 @@ class JaxLightningModule(pl.LightningModule):
         super().__init__()
         self.automatic_optimization = False
         self._jax_step_count = 0
-        # Dummy parameter so PL's optimizer can increment global_step.
-        # Without this, global_step stays at 0 and ModelCheckpoint
-        # skips all best-model saves (PL dedup check).
-        self._dummy_param = torch.nn.Parameter(torch.zeros(1), requires_grad=False)
 
-    def configure_optimizers(self) -> torch.optim.Optimizer:
-        """Dummy optimizer for PL global_step tracking only."""
-        return torch.optim.SGD([self._dummy_param], lr=0.0)
+    def configure_optimizers(self) -> list:
+        """Return empty optimizer list. JAX manages its own optimizers."""
+        return []
 
-    def step_global_step(self) -> None:
-        """Increment PL's global_step via the dummy optimizer.
+    def step_jax(self) -> None:
+        """Increment JAX step counter.
 
         Call this at the end of each training_step so that
-        ModelCheckpoint can correctly save best checkpoints.
+        JaxModelCheckpoint can correctly track progress and save checkpoints.
         """
-        opt = self.optimizers()
-        opt.step()
+        self._jax_step_count += 1
+
+    def step_global_step(self) -> None:
+        """Deprecated: use step_jax() instead."""
+        warnings.warn("step_global_step() is deprecated, use step_jax() instead", DeprecationWarning, stacklevel=2)
+        self.step_jax()
 
     @property
     def jax_step_count(self) -> int:

--- a/src/ml_networks/jax/base.py
+++ b/src/ml_networks/jax/base.py
@@ -72,7 +72,7 @@ class BaseModule(nnx.Module):
         nnx.update(self, state)
 
 
-class JaxLightningModule(pl.LightningModule):
+class JaxLightningModule(pl.LightningModule, nnx.Module):
     """Base class for JAX models trained with PyTorch Lightning.
 
     Subclasses should:

--- a/src/ml_networks/jax/distributions.py
+++ b/src/ml_networks/jax/distributions.py
@@ -76,12 +76,28 @@ class NormalStoch:
     def shape(self) -> NormalShape:
         return NormalShape(self.mean.shape, self.std.shape, self.stoch.shape)
 
-    def detach(self) -> NormalStoch:
-        """Stop gradient equivalent."""
+    def stop_gradient(self) -> NormalStoch:
+        """Apply stop_gradient to all members."""
         return NormalStoch(
             jax.lax.stop_gradient(self.mean),
             jax.lax.stop_gradient(self.std),
             jax.lax.stop_gradient(self.stoch),
+        )
+
+    def copy(self) -> NormalStoch:
+        """Return a copy of this distribution state."""
+        return NormalStoch(self.mean.copy(), self.std.copy(), self.stoch.copy())
+
+    def to_numpy(self) -> NormalStoch:
+        """Convert all members to NumPy arrays."""
+        return NormalStoch(np.asarray(self.mean), np.asarray(self.std), np.asarray(self.stoch))  # type: ignore[arg-type]
+
+    def device_put(self, device: jax.Device | None = None) -> NormalStoch:
+        """Place all members on the specified device."""
+        return NormalStoch(
+            jax.device_put(self.mean, device),
+            jax.device_put(self.std, device),
+            jax.device_put(self.stoch, device),
         )
 
     def reshape(self, *shape: int) -> NormalStoch:
@@ -91,13 +107,48 @@ class NormalStoch:
             self.stoch.reshape(*shape),
         )
 
-    def flatten(self, start_dim: int = 0, end_dim: int = -1) -> NormalStoch:
-        """Flatten along specified dimensions."""
+    def flatten(self, start_axis: int = 0, end_axis: int = -1) -> NormalStoch:
+        """Flatten along specified axes."""
         ndim = self.mean.ndim
-        if end_dim < 0:
-            end_dim = ndim + end_dim
-        new_shape = (*self.mean.shape[:start_dim], -1, *self.mean.shape[end_dim + 1 :])
+        if end_axis < 0:
+            end_axis = ndim + end_axis
+        new_shape = (*self.mean.shape[:start_axis], -1, *self.mean.shape[end_axis + 1 :])
         return self.reshape(*new_shape)
+
+    def squeeze(self, axis: int) -> NormalStoch:
+        return NormalStoch(
+            jnp.squeeze(self.mean, axis=axis),
+            jnp.squeeze(self.std, axis=axis),
+            jnp.squeeze(self.stoch, axis=axis),
+        )
+
+    def expand_dims(self, axis: int) -> NormalStoch:
+        return NormalStoch(
+            jnp.expand_dims(self.mean, axis=axis),
+            jnp.expand_dims(self.std, axis=axis),
+            jnp.expand_dims(self.stoch, axis=axis),
+        )
+
+    def transpose(self, *axes: int) -> NormalStoch:
+        return NormalStoch(
+            jnp.transpose(self.mean, axes),
+            jnp.transpose(self.std, axes),
+            jnp.transpose(self.stoch, axes),
+        )
+
+    def swapaxes(self, axis0: int, axis1: int) -> NormalStoch:
+        return NormalStoch(
+            jnp.swapaxes(self.mean, axis0, axis1),
+            jnp.swapaxes(self.std, axis0, axis1),
+            jnp.swapaxes(self.stoch, axis0, axis1),
+        )
+
+    def broadcast(self, shape: tuple[int, ...]) -> NormalStoch:
+        return NormalStoch(
+            jnp.broadcast_to(self.mean, shape),
+            jnp.broadcast_to(self.std, shape),
+            jnp.broadcast_to(self.stoch, shape),
+        )
 
     def save(self, path: str) -> None:
         os.makedirs(path, exist_ok=True)
@@ -137,19 +188,28 @@ class CategoricalStoch:
     def __len__(self) -> int:
         return self.stoch.shape[0]
 
-    def squeeze(self, axis: int) -> CategoricalStoch:
-        return CategoricalStoch(
-            jnp.squeeze(self.logits, axis=axis),
-            jnp.squeeze(self.probs, axis=axis),
-            jnp.squeeze(self.stoch, axis=axis),
-        )
-
-    def detach(self) -> CategoricalStoch:
-        """Stop gradient equivalent."""
+    def stop_gradient(self) -> CategoricalStoch:
+        """Apply stop_gradient to all members."""
         return CategoricalStoch(
             jax.lax.stop_gradient(self.logits),
             jax.lax.stop_gradient(self.probs),
             jax.lax.stop_gradient(self.stoch),
+        )
+
+    def copy(self) -> CategoricalStoch:
+        """Return a copy of this distribution state."""
+        return CategoricalStoch(self.logits.copy(), self.probs.copy(), self.stoch.copy())
+
+    def to_numpy(self) -> CategoricalStoch:
+        """Convert all members to NumPy arrays."""
+        return CategoricalStoch(np.asarray(self.logits), np.asarray(self.probs), np.asarray(self.stoch))  # type: ignore[arg-type]
+
+    def device_put(self, device: jax.Device | None = None) -> CategoricalStoch:
+        """Place all members on the specified device."""
+        return CategoricalStoch(
+            jax.device_put(self.logits, device),
+            jax.device_put(self.probs, device),
+            jax.device_put(self.stoch, device),
         )
 
     def reshape(self, *shape: int) -> CategoricalStoch:
@@ -157,6 +217,49 @@ class CategoricalStoch:
             self.logits.reshape(*shape),
             self.probs.reshape(*shape),
             self.stoch.reshape(*shape),
+        )
+
+    def flatten(self, start_axis: int = 0, end_axis: int = -1) -> CategoricalStoch:
+        """Flatten along specified axes."""
+        ndim = self.logits.ndim
+        if end_axis < 0:
+            end_axis = ndim + end_axis
+        new_shape = (*self.logits.shape[:start_axis], -1, *self.logits.shape[end_axis + 1 :])
+        return self.reshape(*new_shape)
+
+    def squeeze(self, axis: int) -> CategoricalStoch:
+        return CategoricalStoch(
+            jnp.squeeze(self.logits, axis=axis),
+            jnp.squeeze(self.probs, axis=axis),
+            jnp.squeeze(self.stoch, axis=axis),
+        )
+
+    def expand_dims(self, axis: int) -> CategoricalStoch:
+        return CategoricalStoch(
+            jnp.expand_dims(self.logits, axis=axis),
+            jnp.expand_dims(self.probs, axis=axis),
+            jnp.expand_dims(self.stoch, axis=axis),
+        )
+
+    def transpose(self, *axes: int) -> CategoricalStoch:
+        return CategoricalStoch(
+            jnp.transpose(self.logits, axes),
+            jnp.transpose(self.probs, axes),
+            jnp.transpose(self.stoch, axes),
+        )
+
+    def swapaxes(self, axis0: int, axis1: int) -> CategoricalStoch:
+        return CategoricalStoch(
+            jnp.swapaxes(self.logits, axis0, axis1),
+            jnp.swapaxes(self.probs, axis0, axis1),
+            jnp.swapaxes(self.stoch, axis0, axis1),
+        )
+
+    def broadcast(self, shape: tuple[int, ...]) -> CategoricalStoch:
+        return CategoricalStoch(
+            jnp.broadcast_to(self.logits, shape),
+            jnp.broadcast_to(self.probs, shape),
+            jnp.broadcast_to(self.stoch, shape),
         )
 
     @property
@@ -208,19 +311,28 @@ class BernoulliStoch:
     def shape(self) -> BernoulliShape:
         return BernoulliShape(self.logits.shape, self.probs.shape, self.stoch.shape)
 
-    def squeeze(self, axis: int) -> BernoulliStoch:
-        return BernoulliStoch(
-            jnp.squeeze(self.logits, axis=axis),
-            jnp.squeeze(self.probs, axis=axis),
-            jnp.squeeze(self.stoch, axis=axis),
-        )
-
-    def detach(self) -> BernoulliStoch:
-        """Stop gradient equivalent."""
+    def stop_gradient(self) -> BernoulliStoch:
+        """Apply stop_gradient to all members."""
         return BernoulliStoch(
             jax.lax.stop_gradient(self.logits),
             jax.lax.stop_gradient(self.probs),
             jax.lax.stop_gradient(self.stoch),
+        )
+
+    def copy(self) -> BernoulliStoch:
+        """Return a copy of this distribution state."""
+        return BernoulliStoch(self.logits.copy(), self.probs.copy(), self.stoch.copy())
+
+    def to_numpy(self) -> BernoulliStoch:
+        """Convert all members to NumPy arrays."""
+        return BernoulliStoch(np.asarray(self.logits), np.asarray(self.probs), np.asarray(self.stoch))  # type: ignore[arg-type]
+
+    def device_put(self, device: jax.Device | None = None) -> BernoulliStoch:
+        """Place all members on the specified device."""
+        return BernoulliStoch(
+            jax.device_put(self.logits, device),
+            jax.device_put(self.probs, device),
+            jax.device_put(self.stoch, device),
         )
 
     def reshape(self, *shape: int) -> BernoulliStoch:
@@ -228,6 +340,49 @@ class BernoulliStoch:
             self.logits.reshape(*shape),
             self.probs.reshape(*shape),
             self.stoch.reshape(*shape),
+        )
+
+    def flatten(self, start_axis: int = 0, end_axis: int = -1) -> BernoulliStoch:
+        """Flatten along specified axes."""
+        ndim = self.logits.ndim
+        if end_axis < 0:
+            end_axis = ndim + end_axis
+        new_shape = (*self.logits.shape[:start_axis], -1, *self.logits.shape[end_axis + 1 :])
+        return self.reshape(*new_shape)
+
+    def squeeze(self, axis: int) -> BernoulliStoch:
+        return BernoulliStoch(
+            jnp.squeeze(self.logits, axis=axis),
+            jnp.squeeze(self.probs, axis=axis),
+            jnp.squeeze(self.stoch, axis=axis),
+        )
+
+    def expand_dims(self, axis: int) -> BernoulliStoch:
+        return BernoulliStoch(
+            jnp.expand_dims(self.logits, axis=axis),
+            jnp.expand_dims(self.probs, axis=axis),
+            jnp.expand_dims(self.stoch, axis=axis),
+        )
+
+    def transpose(self, *axes: int) -> BernoulliStoch:
+        return BernoulliStoch(
+            jnp.transpose(self.logits, axes),
+            jnp.transpose(self.probs, axes),
+            jnp.transpose(self.stoch, axes),
+        )
+
+    def swapaxes(self, axis0: int, axis1: int) -> BernoulliStoch:
+        return BernoulliStoch(
+            jnp.swapaxes(self.logits, axis0, axis1),
+            jnp.swapaxes(self.probs, axis0, axis1),
+            jnp.swapaxes(self.stoch, axis0, axis1),
+        )
+
+    def broadcast(self, shape: tuple[int, ...]) -> BernoulliStoch:
+        return BernoulliStoch(
+            jnp.broadcast_to(self.logits, shape),
+            jnp.broadcast_to(self.probs, shape),
+            jnp.broadcast_to(self.stoch, shape),
         )
 
     def save(self, path: str) -> None:

--- a/src/ml_networks/jax/distributions.py
+++ b/src/ml_networks/jax/distributions.py
@@ -397,6 +397,24 @@ class BernoulliStoch:
 
 StochState = NormalStoch | CategoricalStoch | BernoulliStoch
 
+# Register as JAX pytree nodes so that StochState objects can be used
+# with jax.jit, jax.vmap, jax.tree.map, etc.
+jax.tree_util.register_dataclass(
+    NormalStoch,
+    data_fields=["mean", "std", "stoch"],
+    meta_fields=[],
+)
+jax.tree_util.register_dataclass(
+    CategoricalStoch,
+    data_fields=["logits", "probs", "stoch"],
+    meta_fields=[],
+)
+jax.tree_util.register_dataclass(
+    BernoulliStoch,
+    data_fields=["logits", "probs", "stoch"],
+    meta_fields=[],
+)
+
 
 def cat_dist(stochs: tuple[StochState, ...], axis: int = -1) -> StochState | None:
     """
@@ -572,7 +590,13 @@ class Distribution(nnx.Module):
         if spherical:
             self.codebook = BSQCodebook(self.n_class)
 
-    def normal(self, mu_std: jax.Array, deterministic: bool = False, inv_tmp: float = 1.0) -> NormalStoch:
+    def normal(
+        self,
+        mu_std: jax.Array,
+        deterministic: bool = False,
+        inv_tmp: float = 1.0,
+        key: jax.Array | None = None,
+    ) -> NormalStoch:
         assert mu_std.shape[-1] == self.in_dim * 2, (
             f"mu_std.shape[-1] {mu_std.shape[-1]} and in_dim {self.in_dim} must be the same."
         )
@@ -583,18 +607,26 @@ class Distribution(nnx.Module):
         if deterministic:
             sample = mu
         else:
-            key = self.rngs()
+            if key is None:
+                key = self.rngs()
             sample = mu + std * jax.random.normal(key, mu.shape)
 
         return NormalStoch(mu, std, sample)
 
-    def categorical(self, logits: jax.Array, deterministic: bool = False, inv_tmp: float = 1.0) -> CategoricalStoch:
+    def categorical(
+        self,
+        logits: jax.Array,
+        deterministic: bool = False,
+        inv_tmp: float = 1.0,
+        key: jax.Array | None = None,
+    ) -> CategoricalStoch:
         batch_shape = logits.shape[:-1]
         logits_chunks = jnp.split(logits, self.n_groups, axis=-1)
         logits_stacked = jnp.stack(logits_chunks, axis=-2)
         probs = softmax(logits_stacked, axis=-1, temperature=1 / inv_tmp)
 
-        key = self.rngs()
+        if key is None:
+            key = self.rngs()
         # Sample using Gumbel-max trick for one-hot with straight-through
         gumbel_noise = -jnp.log(-jnp.log(jax.random.uniform(key, probs.shape, minval=1e-10, maxval=1.0)))
         y = jnp.log(probs + 1e-10) + gumbel_noise
@@ -611,14 +643,21 @@ class Distribution(nnx.Module):
 
         return CategoricalStoch(logits_stacked, probs, stoch)
 
-    def bernoulli(self, logits: jax.Array, deterministic: bool = False, inv_tmp: float = 1.0) -> BernoulliStoch:
+    def bernoulli(
+        self,
+        logits: jax.Array,
+        deterministic: bool = False,
+        inv_tmp: float = 1.0,
+        key: jax.Array | None = None,
+    ) -> BernoulliStoch:
         batch_shape = logits.shape[:-1]
         chunked_logits = jnp.split(logits, self.n_groups, axis=-1)
         logits_stacked = jnp.stack(chunked_logits, axis=-2)
         logits_stacked = logits_stacked * inv_tmp
         probs = jax.nn.sigmoid(logits_stacked)
 
-        key = self.rngs()
+        if key is None:
+            key = self.rngs()
         # Bernoulli sampling with straight-through
         u = jax.random.uniform(key, probs.shape)
         sample = (u < probs).astype(jnp.float32)
@@ -646,6 +685,7 @@ class Distribution(nnx.Module):
         x: jax.Array,
         deterministic: bool = False,
         inv_tmp: float = 1.0,
+        key: jax.Array | None = None,
     ) -> StochState:
         """
         Compute the posterior distribution.
@@ -658,6 +698,10 @@ class Distribution(nnx.Module):
             Whether to use the deterministic mode. Default is False.
         inv_tmp : float, optional
             Inverse temperature. Default is 1.0.
+        key : jax.Array | None, optional
+            PRNG key. If provided, ``self.rngs()`` is not called, making this
+            method safe for use inside ``jax.lax.scan`` and other JAX transforms
+            that forbid NNX variable mutation. Default is None.
 
         Returns
         -------
@@ -665,11 +709,11 @@ class Distribution(nnx.Module):
             Posterior distribution.
         """
         if self.dist_type == "normal":
-            return self.normal(x, deterministic=deterministic, inv_tmp=inv_tmp)
+            return self.normal(x, deterministic=deterministic, inv_tmp=inv_tmp, key=key)
         if self.dist_type == "categorical":
-            return self.categorical(x, deterministic=deterministic, inv_tmp=inv_tmp)
+            return self.categorical(x, deterministic=deterministic, inv_tmp=inv_tmp, key=key)
         if self.dist_type == "bernoulli":
-            return self.bernoulli(x, deterministic=deterministic, inv_tmp=inv_tmp)
+            return self.bernoulli(x, deterministic=deterministic, inv_tmp=inv_tmp, key=key)
         raise NotImplementedError
 
     def deterministic_onehot(self, input: jax.Array) -> jax.Array:

--- a/src/ml_networks/jax/jax_utils.py
+++ b/src/ml_networks/jax/jax_utils.py
@@ -4,16 +4,22 @@ from __future__ import annotations
 
 import logging
 import random
+import warnings
+from copy import deepcopy
 from typing import Any
+from weakref import proxy
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
 import pytorch_lightning as pl
+import torch
 from einops import rearrange
 from flax import nnx
+from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint as _PLModelCheckpoint
 from pytorch_lightning.callbacks.model_summary import ModelSummary as _PLModelSummary
+from torch import Tensor
 
 from ml_networks.config import SoftmaxTransConfig
 
@@ -444,11 +450,58 @@ class JaxModelSummary(_PLModelSummary):
             _log.info("\n" + summary_table)
 
 
-class JaxTrainer(pl.Trainer):
-    """Flax NNX パラメータ数を正しく表示する PyTorch Lightning Trainer ラッパー.
+class JaxModelCheckpoint(_PLModelCheckpoint):
+    """JAX 用 ModelCheckpoint.
 
-    JaxLightningModule を使用するモデルで ``fit()`` を呼び出すと、
-    Flax NNX モデルのパラメータ数が正しく表示される。
+    PL の ModelCheckpoint は ``trainer.global_step`` で重複チェックを行うが、
+    JaxLightningModule では PL の optimizer を使わないため ``global_step`` が進まない。
+    このクラスは ``_jax_step_count`` ベースで保存判定を行い、
+    ダミーパラメータ・ダミーオプティマイザを不要にする。
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._last_jax_step_saved = 0
+
+    def _should_skip_saving_checkpoint(self, trainer: pl.Trainer) -> bool:
+        from pytorch_lightning.trainer.states import TrainerFn
+
+        pl_module = trainer.lightning_module
+        jax_step = getattr(pl_module, "_jax_step_count", trainer.global_step)
+        return (
+            bool(trainer.fast_dev_run)
+            or trainer.state.fn != TrainerFn.FITTING
+            or trainer.sanity_checking
+            or self._last_jax_step_saved == jax_step
+        )
+
+    def _save_checkpoint(self, trainer: pl.Trainer, filepath: str) -> None:
+        trainer.save_checkpoint(filepath, self.save_weights_only)
+        pl_module = trainer.lightning_module
+        self._last_jax_step_saved = getattr(pl_module, "_jax_step_count", trainer.global_step)
+        self._last_global_step_saved = trainer.global_step
+        self._last_checkpoint_saved = filepath
+        if trainer.is_global_zero:
+            for logger in trainer.loggers:
+                logger.after_save_checkpoint(proxy(self))
+
+    def _monitor_candidates(self, trainer: pl.Trainer) -> dict[str, Tensor]:
+        monitor_candidates = deepcopy(trainer.callback_metrics)
+        epoch = monitor_candidates.get("epoch")
+        monitor_candidates["epoch"] = epoch.int() if isinstance(epoch, Tensor) else torch.tensor(trainer.current_epoch)
+        pl_module = trainer.lightning_module
+        jax_step = getattr(pl_module, "_jax_step_count", trainer.global_step)
+        step = monitor_candidates.get("step")
+        monitor_candidates["step"] = step.int() if isinstance(step, Tensor) else torch.tensor(jax_step)
+        return monitor_candidates
+
+
+class JaxTrainer(pl.Trainer):
+    """JAX モデル用 PyTorch Lightning Trainer ラッパー.
+
+    - Flax NNX パラメータ数を正しく表示 (JaxModelSummary)
+    - JAX step ベースの checkpoint 保存 (JaxModelCheckpoint)
+    - PL の ModelCheckpoint が渡された場合は JaxModelCheckpoint に自動変換
 
     Examples
     --------
@@ -466,6 +519,19 @@ class JaxTrainer(pl.Trainer):
             callbacks = [callbacks]
         else:
             callbacks = list(callbacks)
+
+        # ModelCheckpoint が渡された場合にワーニング
+        for cb in callbacks:
+            if isinstance(cb, _PLModelCheckpoint) and not isinstance(cb, JaxModelCheckpoint):
+                warnings.warn(
+                    "JaxLightningModule では ModelCheckpoint の代わりに"
+                    " JaxModelCheckpoint の使用を推奨します。"
+                    " ModelCheckpoint は global_step ベースの重複チェックを行うため、"
+                    "JAX モデルでは checkpoint が正しく保存されない場合があります。",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
 
         has_summary = any(isinstance(cb, _PLModelSummary) for cb in callbacks)
         if not has_summary:

--- a/src/ml_networks/jax/loss.py
+++ b/src/ml_networks/jax/loss.py
@@ -250,12 +250,12 @@ def kl_balancing(posterior: StochState, prior: StochState, weight: float = 0.8) 
         The KL balancing loss.
     """
     assert 0 <= weight <= 1, "weight should be in the range [0, 1]"
-    kld_prior = weight * posterior.detach().get_distribution().kl_divergence(
+    kld_prior = weight * posterior.stop_gradient().get_distribution().kl_divergence(
         prior.get_distribution(),
     )
 
     kld_posterior = (1 - weight) * posterior.get_distribution().kl_divergence(
-        prior.detach().get_distribution(),
+        prior.stop_gradient().get_distribution(),
     )
 
     return kld_prior + kld_posterior


### PR DESCRIPTION
This pull request introduces significant improvements to the JAX backend of the `ml-networks` library, focusing on enhanced usability, better integration with PyTorch Lightning, and expanded functionality for stochastic distribution classes. The main highlights include a major overhaul of the stochastic distribution (`StochState`) API, improved device and numpy interoperability, and a refactor of the `JaxLightningModule` for cleaner optimizer handling and step tracking.

**JAX Distribution API Enhancements:**

* Added many new utility methods to `NormalStoch`, `CategoricalStoch`, and `BernoulliStoch` classes, including `copy`, `to_numpy`, `device_put`, `flatten`, `expand_dims`, `transpose`, `swapaxes`, and `broadcast`, providing a much richer and more numpy-like API for manipulating stochastic states. The `detach` method was renamed to `stop_gradient` for clarity. [[1]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9L79-R152) [[2]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9L140-R264) [[3]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9L211-R387)
* Registered all `StochState` dataclasses as JAX pytrees, enabling them to be used seamlessly with JAX transformations like `jit`, `vmap`, and `tree_map`.

**JAX Distribution Sampling Improvements:**

* Updated the `normal`, `categorical`, and `bernoulli` methods in the distribution class to accept an optional PRNG `key` argument. This makes the API compatible with JAX transforms (like `lax.scan`) that forbid variable mutation, improving functional purity and composability. The main `__call__` method now also accepts and forwards this `key`. (F7a775adL417R76, [[1]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9R610-R628) [[2]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9L459-R659) [[3]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9R688) [[4]](diffhunk://#diff-88ffa448d917d7935c6c7c1518cdceeab21866fa520578584fe120262b51a9d9R701-R716)

**JaxLightningModule and PyTorch Lightning Integration:**

* Refactored `JaxLightningModule` to remove the dummy torch parameter and optimizer previously used for global step tracking. Now, no optimizer is returned, and a new `step_jax()` method increments the JAX step counter for checkpointing. The old `step_global_step()` method is deprecated in favor of `step_jax()`. [[1]](diffhunk://#diff-ce59c1b90af930277d24bbce786afebbb1201c90f2f467acf227538f7dbf8881L75-R75) [[2]](diffhunk://#diff-ce59c1b90af930277d24bbce786afebbb1201c90f2f467acf227538f7dbf8881L89-R105)
* Added `JaxLightningModule` and `JaxModelCheckpoint` to the JAX module's public API, improving discoverability and import ergonomics. [[1]](diffhunk://#diff-d33552b5776294dd62d3471c6b1ac16997a37cc152b0b897f53be72ed6d9c2b4L2-R2) [[2]](diffhunk://#diff-d33552b5776294dd62d3471c6b1ac16997a37cc152b0b897f53be72ed6d9c2b4R17) [[3]](diffhunk://#diff-d33552b5776294dd62d3471c6b1ac16997a37cc152b0b897f53be72ed6d9c2b4R71-R72)

**Other Improvements:**

* Bumped the project version to `0.2.4` to reflect these new features and API changes.
* Added missing imports and minor code cleanups in `jax_utils.py`.

These changes collectively make the JAX backend more robust, user-friendly, and better aligned with both JAX and PyTorch Lightning best practices.