### PR TITLE
Fix normalization bug and improve ViT with pos_emb and cls token

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ pip install jax flax optax distrax
 まず、設定ファイル `configs/mlp_config.yaml` を作成します：
 
 ```yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:
@@ -74,7 +74,8 @@ print(y.shape)  # torch.Size([32, 8])
 #### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import MLPLayer, MLPConfig, LinearConfig
+from ml_networks.torch import MLPLayer
+from ml_networks import MLPConfig, LinearConfig
 import torch
 
 # MLPの設定
@@ -109,7 +110,7 @@ print(y.shape)  # torch.Size([32, 8])
 設定ファイル `configs/encoder_config.yaml` を作成します：
 
 ```yaml
-_target_: ml_networks.vision.Encoder
+_target_: ml_networks.torch.vision.Encoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 encoder_cfg:
@@ -159,7 +160,8 @@ print(z.shape)  # torch.Size([32, 64])
 #### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import Encoder, ConvNetConfig, ConvConfig, LinearConfig
+from ml_networks.torch import Encoder
+from ml_networks import ConvNetConfig, ConvConfig, LinearConfig
 import torch
 
 # Encoderの設定
@@ -194,7 +196,8 @@ print(z.shape)  # torch.Size([32, 64])
 特徴量から画像を再構成するDecoderを使用します：
 
 ```python
-from ml_networks import Decoder, ConvNetConfig, ConvConfig, LinearConfig
+from ml_networks.torch import Decoder
+from ml_networks import ConvNetConfig, ConvConfig, LinearConfig
 import torch
 
 # Decoderの設定
@@ -229,7 +232,8 @@ print(predicted_obs.shape)  # torch.Size([32, 3, 64, 64])
 特徴量を分布に変換します：
 
 ```python
-from ml_networks import Distribution, Encoder, ConvNetConfig, ConvConfig, MLPConfig, LinearConfig
+from ml_networks.torch import Distribution, Encoder
+from ml_networks import ConvNetConfig, ConvConfig, MLPConfig, LinearConfig
 import torch
 
 # Encoderの設定（分布のパラメータを出力するため、特徴量次元の2倍が必要）

--- a/docs/guides/config-management.md
+++ b/docs/guides/config-management.md
@@ -30,7 +30,7 @@ pip install hydra-core
 **例: `configs/mlp_config.yaml`**
 
 ```yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:
@@ -49,7 +49,7 @@ mlp_config:
 **例: `configs/encoder_config.yaml`**
 
 ```yaml
-_target_: ml_networks.vision.Encoder
+_target_: ml_networks.torch.vision.Encoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 encoder_cfg:
@@ -115,7 +115,7 @@ print(y.shape)  # torch.Size([32, 8])
 
 ```yaml
 encoder:
-  _target_: ml_networks.vision.Encoder
+  _target_: ml_networks.torch.vision.Encoder
   feature_dim: 128  # 正規分布の場合、特徴量次元の2倍が必要
   obs_shape: [3, 64, 64]
   encoder_cfg:
@@ -138,7 +138,7 @@ encoder:
       bias: true
 
 distribution:
-  _target_: ml_networks.distributions.Distribution
+  _target_: ml_networks.torch.distributions.Distribution
   in_dim: 64
   dist: normal
   n_groups: 1
@@ -178,7 +178,7 @@ cfg = OmegaConf.load("configs/encoder_config.yaml")
 encoder_cfg = instantiate(cfg.encoder_cfg)
 
 # その後、手動でEncoderを作成
-from ml_networks.vision import Encoder
+from ml_networks.torch.vision import Encoder
 encoder = Encoder(
     feature_dim=cfg.feature_dim,
     obs_shape=tuple(cfg.obs_shape),
@@ -246,7 +246,7 @@ obs_shape: [3, 128, 128]
 
 ```yaml
 # configs/mlp_simple.yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:
@@ -264,7 +264,7 @@ mlp_config:
 
 ```yaml
 # configs/encoder_resnet.yaml
-_target_: ml_networks.vision.Encoder
+_target_: ml_networks.torch.vision.Encoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 encoder_cfg:
@@ -291,7 +291,7 @@ full_connection_cfg:
 
 ```yaml
 # configs/decoder_config.yaml
-_target_: ml_networks.vision.Decoder
+_target_: ml_networks.torch.vision.Decoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 decoder_cfg:

--- a/docs/guides/data-io.md
+++ b/docs/guides/data-io.md
@@ -28,7 +28,7 @@ loaded_data = load_blosc2("dataset/image.blosc2")
 分布データも保存できます：
 
 ```python
-from ml_networks import Distribution
+from ml_networks.torch import Distribution
 
 dist = Distribution(
     in_dim=feature_dim,

--- a/docs/guides/decoder.md
+++ b/docs/guides/decoder.md
@@ -16,7 +16,7 @@ Decoderは特徴量から画像などを再構成するモジュールです。E
 設定ファイル `configs/decoder_config.yaml` を作成します：
 
 ```yaml
-_target_: ml_networks.vision.Decoder
+_target_: ml_networks.torch.vision.Decoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 decoder_cfg:
@@ -67,7 +67,8 @@ print(predicted_obs.shape)  # torch.Size([32, 3, 64, 64])
 ### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import Decoder, ConvNetConfig, ConvConfig, LinearConfig
+from ml_networks.torch import Decoder
+from ml_networks import ConvNetConfig, ConvConfig, LinearConfig
 import torch
 
 # Decoderの設定
@@ -130,7 +131,7 @@ ResNetとPixelShuffleを組み合わせたデコーダ：
 **YAMLファイル** (`configs/decoder_resnet.yaml`):
 
 ```yaml
-_target_: ml_networks.vision.Decoder
+_target_: ml_networks.torch.vision.Decoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 decoder_cfg:

--- a/docs/guides/distributions.md
+++ b/docs/guides/distributions.md
@@ -19,7 +19,7 @@
 
 ```yaml
 encoder:
-  _target_: ml_networks.vision.Encoder
+  _target_: ml_networks.torch.vision.Encoder
   feature_dim: 128  # 正規分布の場合、特徴量次元の2倍が必要
   obs_shape: [3, 64, 64]
   encoder_cfg:
@@ -52,7 +52,7 @@ encoder:
       bias: true
 
 distribution:
-  _target_: ml_networks.distributions.Distribution
+  _target_: ml_networks.torch.distributions.Distribution
   in_dim: 64
   dist: normal
   n_groups: 1
@@ -94,7 +94,8 @@ kld = D.kl_divergence(torch_dist_z, normal).mean()
 #### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import Distribution, Encoder, ConvNetConfig, ConvConfig, MLPConfig, LinearConfig
+from ml_networks.torch import Distribution, Encoder
+from ml_networks import ConvNetConfig, ConvConfig, MLPConfig, LinearConfig
 import torch
 import torch.distributions as D
 
@@ -181,7 +182,7 @@ dist = Distribution(
 ### stack
 
 ```python
-from ml_networks import stack_dist
+from ml_networks.torch import stack_dist
 
 dist_list = []
 for batch in dataloader:
@@ -199,7 +200,7 @@ print(stacked_dist.shape)
 ### concatenate
 
 ```python
-from ml_networks import cat_dist
+from ml_networks.torch import cat_dist
 
 # 分布データをconcatenate
 concatenated_dist = cat_dist(dist_list, dim=-1)

--- a/docs/guides/encoder.md
+++ b/docs/guides/encoder.md
@@ -16,7 +16,7 @@ Encoderは画像などの入力を特徴量に変換するモジュールです�
 設定ファイル `configs/encoder_config.yaml` を作成します：
 
 ```yaml
-_target_: ml_networks.vision.Encoder
+_target_: ml_networks.torch.vision.Encoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 encoder_cfg:
@@ -66,7 +66,8 @@ print(z.shape)  # torch.Size([32, 64])
 ### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import Encoder, ConvNetConfig, ConvConfig, LinearConfig
+from ml_networks.torch import Encoder
+from ml_networks import ConvNetConfig, ConvConfig, LinearConfig
 import torch
 
 # Encoderの設定
@@ -136,7 +137,7 @@ ResNetとPixelUnShuffleを組み合わせたエンコーダ：
 **YAMLファイル** (`configs/encoder_resnet.yaml`):
 
 ```yaml
-_target_: ml_networks.vision.Encoder
+_target_: ml_networks.torch.vision.Encoder
 feature_dim: 64
 obs_shape: [3, 64, 64]
 encoder_cfg:
@@ -230,7 +231,8 @@ full_connection_cfg = None
 ## 独立したSpatialSoftmaxの使用
 
 ```python
-from ml_networks import SpatialSoftmaxConfig, SpatialSoftmax
+from ml_networks.torch import SpatialSoftmax
+from ml_networks import SpatialSoftmaxConfig
 
 data = torch.randn(32, 3, 64, 64)
 cfg = SpatialSoftmaxConfig(

--- a/docs/guides/loss-functions.md
+++ b/docs/guides/loss-functions.md
@@ -9,7 +9,7 @@
 ### 多クラス分類の場合
 
 ```python
-from ml_networks import focal_loss
+from ml_networks.torch import focal_loss
 import torch
 
 logits = torch.randn(32, 10)
@@ -25,7 +25,7 @@ loss = focal_loss(
 ### 二値分類の場合
 
 ```python
-from ml_networks import binary_focal_loss
+from ml_networks.torch import binary_focal_loss
 
 logits = torch.randn(32)
 labels = torch.randint(0, 2, (32,))
@@ -42,7 +42,7 @@ loss = binary_focal_loss(
 画像再構成の損失関数です。損失の勾配が安定します。
 
 ```python
-from ml_networks import charbonnier
+from ml_networks.torch import charbonnier
 
 loss = charbonnier(
     predicted_obs,
@@ -58,7 +58,7 @@ loss = charbonnier(
 画像自体でなく、画像の周波数成分に焦点を当てた損失関数です。Focal Lossを画像に適用したものという位置付けです。
 
 ```python
-from ml_networks import FocalFrequencyLoss
+from ml_networks.torch import FocalFrequencyLoss
 
 loss_fn = FocalFrequencyLoss(
     loss_weight=1.0,      # Focal Frequency Lossの重み
@@ -77,7 +77,7 @@ loss = loss_fn(predicted_obs, obs)
 分布間のKLダイバージェンスを計算します。
 
 ```python
-from ml_networks import kl_divergence
+from ml_networks.torch import kl_divergence
 import torch.distributions as D
 
 # 例: 正規分布間のKLダイバージェンス
@@ -91,7 +91,7 @@ kld = kl_divergence(dist1, dist2)
 複数のKLダイバージェンスをバランスするためのユーティリティです。
 
 ```python
-from ml_networks import kl_balancing
+from ml_networks.torch import kl_balancing
 
 # 複数のKLダイバージェンスをバランス
 kld_list = [kld1, kld2, kld3]

--- a/docs/guides/mlp.md
+++ b/docs/guides/mlp.md
@@ -12,7 +12,7 @@ MLP（多層パーセプトロン）の使用方法を説明します。
 設定ファイル `configs/mlp_config.yaml` を作成します：
 
 ```yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:
@@ -52,7 +52,8 @@ print(y.shape)  # torch.Size([32, 8])
 ### 方法2: Pythonコードで直接設定する
 
 ```python
-from ml_networks import MLPLayer, MLPConfig, LinearConfig
+from ml_networks.torch import MLPLayer
+from ml_networks import MLPConfig, LinearConfig
 import torch
 
 mlp_config = MLPConfig(
@@ -111,7 +112,7 @@ print(y.shape)  # torch.Size([32, 8])
 **YAMLファイル** (`configs/mlp_dropout.yaml`):
 
 ```yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:
@@ -142,7 +143,7 @@ mlp = instantiate(cfg)
 **YAMLファイル** (`configs/mlp_layernorm.yaml`):
 
 ```yaml
-_target_: ml_networks.layers.MLPLayer
+_target_: ml_networks.torch.layers.MLPLayer
 input_dim: 16
 output_dim: 8
 mlp_config:

--- a/docs/guides/utilities.md
+++ b/docs/guides/utilities.md
@@ -12,7 +12,7 @@ stringで活性化関数を指定できます。PyTorchに実装されている�
 - **"TanhExp"**: Mishの改善版という位置付け
 
 ```python
-from ml_networks import Activation
+from ml_networks.torch import Activation
 
 act = Activation("ReLU")
 x = torch.randn(32, 64)
@@ -24,7 +24,7 @@ y = act(x)
 stringで最適化手法を指定できます。PyTorchに実装されている最適化手法に加えて、[pytorch_optimizer](https://pypi.org/project/pytorch_optimizer/)に実装されている最適化手法が使えます。
 
 ```python
-from ml_networks import get_optimizer
+from ml_networks.torch import get_optimizer
 import torch.nn as nn
 
 model = nn.Linear(16, 8)
@@ -38,7 +38,8 @@ optimizer = get_optimizer(model.parameters(), "Adam", lr=1e-3, weight_decay=1e-4
 再現性を担保するためにseedを固定できます。
 
 ```python
-from ml_networks import torch_fix_seed, determine_loader
+from ml_networks.torch import torch_fix_seed
+from ml_networks import determine_loader
 
 # random, np, torchのseedを固定する
 # さらにGPU関連の再現性も（ある程度）担保
@@ -70,7 +71,7 @@ loader = determine_loader(
 Gumbel Softmaxを使用できます。
 
 ```python
-from ml_networks import gumbel_softmax
+from ml_networks.torch import gumbel_softmax
 
 logits = torch.randn(32, 10)
 samples = gumbel_softmax(logits, temperature=1.0, hard=True)
@@ -81,7 +82,7 @@ samples = gumbel_softmax(logits, temperature=1.0, hard=True)
 カスタムSoftmaxを使用できます。
 
 ```python
-from ml_networks import softmax
+from ml_networks.torch import softmax
 
 logits = torch.randn(32, 10)
 probs = softmax(logits, dim=-1)
@@ -92,7 +93,7 @@ probs = softmax(logits, dim=-1)
 Min-Max正規化を実行できます。
 
 ```python
-from ml_networks import MinMaxNormalize
+from ml_networks.torch import MinMaxNormalize
 
 normalize = MinMaxNormalize(min=0.0, max=1.0)
 data = torch.randn(32, 3, 64, 64)
@@ -104,7 +105,7 @@ normalized_data = normalize(data)
 Softmax変換を実行できます。
 
 ```python
-from ml_networks import SoftmaxTransformation
+from ml_networks.torch import SoftmaxTransformation
 
 transform = SoftmaxTransformation(temperature=1.0)
 data = torch.randn(32, 10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml-networks"
-version = "0.2.4"
+version = "0.2.5"
 description = "A unified deep learning model building library for PyTorch and JAX with shared dataclass-based configuration"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/ml_networks/config.py
+++ b/src/ml_networks/config.py
@@ -442,6 +442,9 @@ class ViTConfig:
         Whether to use class token. Default is True.
     init_channel : int
         Initial number of channels. Default is 16.
+    decoder_output_activation : str
+        Activation function applied to the reconstructed pixel values in decoder mode.
+        Ignored in encoder mode. Default is "Identity" (no activation).
     """
 
     patch_size: int
@@ -449,6 +452,7 @@ class ViTConfig:
     cls_token: bool = True
     init_channel: int = 16
     unpatchify: bool = False
+    decoder_output_activation: str = "Identity"
 
 
 @dataclass

--- a/src/ml_networks/config.py
+++ b/src/ml_networks/config.py
@@ -426,6 +426,12 @@ class TransformerConfig:
     hidden_activation: Literal["ReLU", "GELU"] = "GELU"
     output_activation: str = "GeLU"
 
+    def dictcfg2dict(self) -> None:
+        """Convert dictConfig to dict for `TransformerConfig`."""
+        for key, value in self.__dict__.items():
+            if isinstance(value, DictConfig | ListConfig | list | tuple | dict):
+                setattr(self, key, convert_dictconfig_to_dict(value))
+
 
 @dataclass
 class ViTConfig:
@@ -453,6 +459,13 @@ class ViTConfig:
     init_channel: int = 16
     unpatchify: bool = False
     decoder_output_activation: str = "Identity"
+
+    def dictcfg2dict(self) -> None:
+        """Convert dictConfig to dict for `ViTConfig`."""
+        self.transformer_cfg.dictcfg2dict()
+        for key, value in self.__dict__.items():
+            if isinstance(value, DictConfig | ListConfig | list | tuple | dict):
+                setattr(self, key, convert_dictconfig_to_dict(value))
 
 
 @dataclass

--- a/src/ml_networks/jax/layers.py
+++ b/src/ml_networks/jax/layers.py
@@ -389,6 +389,7 @@ class MLPLayer(nnx.Module):
         )
         last_cfg = deepcopy(self.cfg.linear_cfg)
         last_cfg.activation = self.cfg.output_activation
+        last_cfg.norm = "none"
         layers.append(LinearNormActivation(self.hidden_dim, self.output_dim, last_cfg, rngs=rngs))
         return layers
 

--- a/src/ml_networks/jax/vision.py
+++ b/src/ml_networks/jax/vision.py
@@ -541,6 +541,7 @@ class ViT(nnx.Module):
         self.decoder_norm = nnx.LayerNorm(num_features=d_model, rngs=rngs)
         out_patch_dim = self.patch_size**2 * self.obs_shape[2]
         self.out_proj = nnx.Linear(d_model, out_patch_dim, rngs=rngs)
+        self.output_activation = Activation(self.cfg.decoder_output_activation)
         self.n_patches = n_patches
 
     def __call__(self, x: jax.Array, *, return_cls_token: bool = False) -> jax.Array:
@@ -592,7 +593,7 @@ class ViT(nnx.Module):
         for block in self.decoder_blocks:
             queries = block(queries, memory)
         queries = self.decoder_norm(queries)
-        patches = self.out_proj(queries)  # (B, P, p*p*C)
+        patches = self.output_activation(self.out_proj(queries))  # (B, P, p*p*C)
         return self.unpatchify(patches)
 
     def patchify(self, imgs: jax.Array) -> jax.Array:

--- a/src/ml_networks/jax/vision.py
+++ b/src/ml_networks/jax/vision.py
@@ -21,6 +21,7 @@ from ml_networks.config import (
     SpatialSoftmaxConfig,
     ViTConfig,
 )
+from ml_networks.jax.activations import Activation
 from ml_networks.jax.layers import (
     Attention2d,
     ConvNormActivation,
@@ -29,10 +30,8 @@ from ml_networks.jax.layers import (
     LinearNormActivation,
     MLPLayer,
     PatchEmbed,
-    PositionalEncoding,
     ResidualBlock,
     SpatialSoftmax,
-    TransformerLayer,
 )
 from ml_networks.utils import conv_out_shape, conv_transpose_in_shape
 
@@ -68,14 +67,31 @@ class Encoder(nnx.Module):
     ) -> None:
         self.obs_shape = obs_shape
         self.feature_dim = feature_dim
+        self._is_vit = isinstance(backbone_cfg, ViTConfig)
 
         self.encoder: nnx.Module
+        self.fc: nnx.Module
         if isinstance(backbone_cfg, ViTConfig):
             self.encoder = ViT(obs_shape, backbone_cfg, rngs=rngs)
-            self.last_channel: int = self.encoder.last_channel
-            self.conved_size: int = cast("int", self.encoder.conved_size)
-            self.conved_shape: tuple[int, ...] = cast("tuple[int, ...]", self.encoder.conved_shape)
-        elif isinstance(backbone_cfg, ConvNetConfig):
+            d_model = backbone_cfg.transformer_cfg.d_model
+            self.last_channel: int = d_model
+            self.conved_size: int = d_model
+            self.conved_shape: tuple[int, ...] = (1, 1)
+            assert isinstance(feature_dim, int), "feature_dim must be int when using ViTConfig backbone"
+            if isinstance(fc_cfg, MLPConfig):
+                self.fc = MLPLayer(d_model, feature_dim, fc_cfg, rngs=rngs)
+            elif isinstance(fc_cfg, LinearConfig):
+                self.fc = LinearNormActivation(d_model, feature_dim, fc_cfg, rngs=rngs)
+            elif fc_cfg is None:
+                assert d_model == feature_dim, (
+                    f"feature_dim must equal transformer d_model when fc_cfg is None, got {feature_dim} vs {d_model}"
+                )
+                self.fc = Identity()
+            else:
+                msg = f"fc_cfg type {type(fc_cfg)} is not supported with ViTConfig backbone"
+                raise NotImplementedError(msg)
+            return
+        if isinstance(backbone_cfg, ConvNetConfig):
             self.encoder = ConvNet(obs_shape, backbone_cfg, rngs=rngs)
             self.last_channel = self.encoder.last_channel
             self.conved_size = cast("int", self.encoder.conved_size)
@@ -96,7 +112,6 @@ class Encoder(nnx.Module):
                 f"{feature_dim} != {(self.last_channel, *self.conved_shape)}"
             )
 
-        self.fc: nnx.Module
         if isinstance(fc_cfg, MLPConfig):
             assert isinstance(feature_dim, int)
             self.fc = MLPLayer(self.conved_size, feature_dim, fc_cfg, rngs=rngs)
@@ -153,6 +168,10 @@ class Encoder(nnx.Module):
         batch_shape = x.shape[:-3]
         x = x.reshape(-1, *self.obs_shape)
         x = self.encoder(x)
+        if self._is_vit:
+            # ViT encoder returns the CLS token (B, d_model); fc projects to feature_dim.
+            x = self.fc(x)
+            return x.reshape(*batch_shape, *x.shape[1:])
         if isinstance(self._fc_cfg, AdaptiveAveragePoolingConfig):
             # NHWC adaptive average pooling: (B, H, W, C) -> (B, oh, ow, C)
             pool_size = self._adaptive_pool_output_size
@@ -205,30 +224,57 @@ class Decoder(nnx.Module):
     ) -> None:
         self.obs_shape = obs_shape
         self.feature_dim = feature_dim
+        self._is_vit = isinstance(backbone_cfg, ViTConfig)
+        self.fc: nnx.Module
+        self.input_shape: tuple[int, ...]
+        self.decoder: nnx.Module
 
-        self.input_shape: tuple[int, int, int]
         if isinstance(backbone_cfg, ViTConfig):
-            self.input_shape = ViT.get_input_shape(obs_shape, backbone_cfg)
-        elif isinstance(backbone_cfg, ConvNetConfig):
-            self.input_shape = cast(
+            d_model = backbone_cfg.transformer_cfg.d_model
+            assert isinstance(feature_dim, int), "feature_dim must be int when using ViTConfig backbone"
+            if isinstance(fc_cfg, MLPConfig):
+                self.fc = MLPLayer(feature_dim, d_model, fc_cfg, rngs=rngs)
+            elif isinstance(fc_cfg, LinearConfig):
+                self.fc = LinearNormActivation(feature_dim, d_model, fc_cfg, rngs=rngs)
+            elif fc_cfg is None:
+                assert feature_dim == d_model, (
+                    f"feature_dim must equal transformer d_model when fc_cfg is None, got {feature_dim} vs {d_model}"
+                )
+                self.fc = Identity()
+            else:
+                msg = f"fc_cfg type {type(fc_cfg)} is not supported with ViTConfig backbone"
+                raise NotImplementedError(msg)
+            self.input_shape = (d_model,)
+            self.has_fc = True
+            self.decoder = ViT(
+                in_shape=(d_model,),
+                cfg=backbone_cfg,
+                obs_shape=obs_shape,
+                rngs=rngs,
+            )
+            return
+
+        in_shape3: tuple[int, int, int]
+        if isinstance(backbone_cfg, ConvNetConfig):
+            in_shape3 = cast(
                 "tuple[int, int, int]",
                 ConvTranspose.get_input_shape(obs_shape, backbone_cfg),
             )
         elif isinstance(backbone_cfg, ResNetConfig):
-            self.input_shape = ResNetPixShuffle.get_input_shape(obs_shape, backbone_cfg)
+            in_shape3 = ResNetPixShuffle.get_input_shape(obs_shape, backbone_cfg)
         else:
             msg = f"{type(backbone_cfg)} is not implemented"
             raise NotImplementedError(msg)
+        self.input_shape = in_shape3
 
         if isinstance(feature_dim, int):
             assert fc_cfg is not None, "fc_cfg must be provided if feature_dim is int"
             self.has_fc = True
         else:
-            assert feature_dim == self.input_shape, f"{feature_dim} != {self.input_shape}"
+            assert feature_dim == in_shape3, f"{feature_dim} != {in_shape3}"
             self.has_fc = False
 
-        input_size = int(np.prod(self.input_shape))
-        self.fc: nnx.Module
+        input_size = int(np.prod(in_shape3))
         if isinstance(fc_cfg, MLPConfig):
             assert isinstance(feature_dim, int)
             self.fc = MLPLayer(feature_dim, input_size, fc_cfg, rngs=rngs)
@@ -238,23 +284,16 @@ class Decoder(nnx.Module):
         else:
             self.fc = Identity()
 
-        if isinstance(backbone_cfg, ViTConfig):
-            self.decoder: nnx.Module = ViT(
-                in_shape=self.input_shape,
-                cfg=backbone_cfg,
-                obs_shape=obs_shape,
-                rngs=rngs,
-            )
-        elif isinstance(backbone_cfg, ConvNetConfig):
+        if isinstance(backbone_cfg, ConvNetConfig):
             self.decoder = ConvTranspose(
-                in_shape=self.input_shape,
+                in_shape=in_shape3,
                 obs_shape=obs_shape,
                 cfg=backbone_cfg,
                 rngs=rngs,
             )
         elif isinstance(backbone_cfg, ResNetConfig):
             self.decoder = ResNetPixShuffle(
-                in_shape=self.input_shape,
+                in_shape=in_shape3,
                 obs_shape=obs_shape,
                 cfg=backbone_cfg,
                 rngs=rngs,
@@ -274,6 +313,12 @@ class Decoder(nnx.Module):
         jax.Array
             Decoded tensor of shape (*, H, W, C) in NHWC format.
         """
+        if self._is_vit:
+            batch_shape, data_shape = x.shape[:-1], x.shape[-1:]
+            x = x.reshape(-1, *data_shape)
+            x = self.fc(x)  # (B, d_model)
+            x = self.decoder(x)  # (B, H, W, C)
+            return x.reshape(*batch_shape, *self.obs_shape)
         if self.has_fc:
             batch_shape, data_shape = x.shape[:-1], x.shape[-1:]
         else:
@@ -285,25 +330,130 @@ class Decoder(nnx.Module):
         return x.reshape(*batch_shape, *self.obs_shape)
 
 
+class _ViTEncoderBlock(nnx.Module):
+    """ViT encoder block (pre-norm). Positional embedding is added to query and key only.
+
+    Follows the DETR convention (https://github.com/gokul-pv/DetectionTransformer): at every
+    layer the spatial positional embedding is added to the query and key tensors of the
+    self-attention, while the value tensor is left unmodified.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        dim_ff: int,
+        dropout: float,
+        activation: str,
+        *,
+        rngs: nnx.Rngs,
+    ) -> None:
+        self.norm1 = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.attn = nnx.MultiHeadAttention(
+            num_heads=nhead,
+            in_features=d_model,
+            dropout_rate=dropout,
+            decode=False,
+            rngs=rngs,
+        )
+        self.norm2 = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.linear1 = nnx.Linear(d_model, dim_ff, rngs=rngs)
+        self.activation = Activation(activation)
+        self.linear2 = nnx.Linear(dim_ff, d_model, rngs=rngs)
+        self.dropout: nnx.Module = nnx.Dropout(rate=dropout, rngs=rngs) if dropout > 0 else Identity()
+
+    def __call__(self, x: jax.Array, pos: jax.Array) -> jax.Array:
+        h = self.norm1(x)
+        q = h + pos
+        k = h + pos
+        v = h
+        attn_out = self.attn(q, k, v)
+        x = x + self.dropout(attn_out)
+        h = self.norm2(x)
+        h = self.linear1(h)
+        h = self.activation(h)
+        h = self.dropout(h)
+        h = self.linear2(h)
+        return x + self.dropout(h)
+
+
+class _ViTDecoderBlock(nnx.Module):
+    """ViT decoder block: cross-attention from learnable queries to the projected CLS token.
+
+    Pre-norm cross-attention where the queries are the learnable patch tokens and the
+    key/value come from the projected CLS representation, followed by a residual MLP block.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        dim_ff: int,
+        dropout: float,
+        activation: str,
+        *,
+        rngs: nnx.Rngs,
+    ) -> None:
+        self.norm_q = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.norm_kv = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.cross_attn = nnx.MultiHeadAttention(
+            num_heads=nhead,
+            in_features=d_model,
+            dropout_rate=dropout,
+            decode=False,
+            rngs=rngs,
+        )
+        self.norm_mlp = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.linear1 = nnx.Linear(d_model, dim_ff, rngs=rngs)
+        self.activation = Activation(activation)
+        self.linear2 = nnx.Linear(dim_ff, d_model, rngs=rngs)
+        self.dropout: nnx.Module = nnx.Dropout(rate=dropout, rngs=rngs) if dropout > 0 else Identity()
+
+    def __call__(self, queries: jax.Array, memory: jax.Array) -> jax.Array:
+        q = self.norm_q(queries)
+        kv = self.norm_kv(memory)
+        attn_out = self.cross_attn(q, kv, kv)
+        queries = queries + self.dropout(attn_out)
+        h = self.norm_mlp(queries)
+        h = self.linear1(h)
+        h = self.activation(h)
+        h = self.linear2(h)
+        return queries + self.dropout(h)
+
+
 class ViT(nnx.Module):
     """
     Vision Transformer for Encoder and Decoder (NHWC format).
 
+    The encoder mode (``obs_shape is None``) follows the DETR convention: a learnable per-patch
+    positional embedding is added to the query and key tensors of every self-attention layer
+    (rather than being added once at the input). When ``cfg.cls_token`` is True, a CLS token
+    with its own learnable positional embedding is prepended and the forward pass returns the
+    CLS token of shape ``(B, d_model)``.
+
+    The decoder mode (``obs_shape is not None``) takes a CLS token of shape ``(B, d_model)`` or
+    ``(B, 1, d_model)`` and reconstructs an image. The CLS token is projected to a hidden
+    dimension and used as the key/value of cross-attention. A fixed set of
+    ``P = (H // p) * (W // p)`` learnable query tokens interacts with this representation
+    through several cross-attention layers with residual MLP blocks. Each query is then
+    linearly projected to ``p * p * C`` pixels and rearranged into a ``(B, H, W, C)`` image.
+
     Parameters
     ----------
-    in_shape : tuple[int, int, int]
-        Input shape in (H, W, C) format.
+    in_shape : tuple[int, ...]
+        Encoder mode: image shape ``(H, W, C)`` (NHWC). Decoder mode: ``(d_model,)`` — the CLS
+        token is the input.
     cfg : ViTConfig
         ViT configuration.
     obs_shape : tuple[int, int, int] | None
-        Output shape in (H, W, C) format. If None, acts as encoder.
+        Output shape in (H, W, C) format. If ``None``, acts as encoder.
     rngs : nnx.Rngs
         Random number generators.
     """
 
     def __init__(
         self,
-        in_shape: tuple[int, int, int],
+        in_shape: tuple[int, ...],
         cfg: ViTConfig,
         obs_shape: tuple[int, int, int] | None = None,
         *,
@@ -311,38 +461,87 @@ class ViT(nnx.Module):
     ) -> None:
         self.cfg = cfg
         self.in_shape = in_shape
-        self.obs_shape = obs_shape if obs_shape is not None else in_shape
         self.patch_size = cfg.patch_size
+        self.transformer_cfg = cfg.transformer_cfg
+        self.is_encoder = obs_shape is None
+        self.obs_shape: tuple[int, int, int] = (
+            obs_shape if obs_shape is not None else cast("tuple[int, int, int]", in_shape)
+        )
 
-        t_cfg = cfg.transformer_cfg
-        self.transformer_cfg = t_cfg
-        # NHWC: (H, W, C) -> patch_dim = patch_size^2 * C
-        self.in_patch_dim = self.get_patch_dim(in_shape)
-        self.out_patch_dim = self.get_patch_dim(obs_shape) if obs_shape is not None else t_cfg.d_model
+        d_model = self.transformer_cfg.d_model
+        self.d_model = d_model
 
-        self.positional_encoding = PositionalEncoding(
-            self.in_patch_dim,
-            t_cfg.dropout,
-            max_len=self.get_n_patches(in_shape),
+        if self.is_encoder:
+            self._build_encoder(rngs=rngs)
+            self.last_channel = d_model
+            self.out_patch_dim = d_model
+        else:
+            self._build_decoder(rngs=rngs)
+            self.out_patch_dim = self.patch_size**2 * self.obs_shape[2]
+            self.last_channel = self.out_patch_dim
+        self.output_dim = self.last_channel
+
+    def _build_encoder(self, *, rngs: nnx.Rngs) -> None:
+        cfg = self.cfg
+        t_cfg = self.transformer_cfg
+        d_model = self.d_model
+        assert len(self.in_shape) == 3, "Encoder mode requires in_shape=(H, W, C)"
+        in_shape3 = cast("tuple[int, int, int]", self.in_shape)
+        n_patches = self.get_n_patches(in_shape3)
+
+        self.patch_embed = PatchEmbed(
+            emb_dim=d_model,
+            patch_size=self.patch_size,
+            obs_shape=in_shape3,
             rngs=rngs,
         )
-        self.vit = TransformerLayer(self.in_patch_dim, self.out_patch_dim, t_cfg, rngs=rngs)
+        # Learnable positional embedding added to query and key at every encoder layer.
+        self._pos_emb = nnx.Param(jax.random.normal(rngs(), (1, n_patches, d_model)) * 0.02)
 
-        self.is_encoder = obs_shape is None
-        if self.is_encoder:
-            self.n_patches = self.get_n_patches(in_shape)
-            self.patch_embed = PatchEmbed(
-                emb_dim=self.in_patch_dim,
-                patch_size=self.patch_size,
-                obs_shape=in_shape,
+        if cfg.cls_token:
+            self._cls_token = nnx.Param(jax.random.normal(rngs(), (1, 1, d_model)) * 0.02)
+            self._cls_pos_emb = nnx.Param(jax.random.normal(rngs(), (1, 1, d_model)) * 0.02)
+
+        self.encoder_blocks = [
+            _ViTEncoderBlock(
+                d_model=d_model,
+                nhead=t_cfg.nhead,
+                dim_ff=t_cfg.dim_ff,
+                dropout=t_cfg.dropout,
+                activation=t_cfg.hidden_activation,
                 rngs=rngs,
             )
+            for _ in range(t_cfg.n_layers)
+        ]
+        self.encoder_norm = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.n_patches = n_patches
 
-        self.should_unpatchify = cfg.unpatchify
-        if cfg.cls_token:
-            self._cls_token = nnx.Param(jax.random.normal(rngs(), (1, 1, self.in_patch_dim)) * 0.02)
-        self.last_channel = self.get_n_patches(in_shape)
-        self.output_dim = self.out_patch_dim
+    def _build_decoder(self, *, rngs: nnx.Rngs) -> None:
+        t_cfg = self.transformer_cfg
+        d_model = self.d_model
+        n_patches = self.get_n_patches(self.obs_shape)
+
+        # Learnable patch queries (1, P, d_model). One query per output patch.
+        self._queries = nnx.Param(jax.random.normal(rngs(), (1, n_patches, d_model)) * 0.02)
+        # Project the CLS token to the hidden dimension used as K/V in cross-attention.
+        self.kv_norm = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        self.kv_proj = nnx.Linear(d_model, d_model, rngs=rngs)
+
+        self.decoder_blocks = [
+            _ViTDecoderBlock(
+                d_model=d_model,
+                nhead=t_cfg.nhead,
+                dim_ff=t_cfg.dim_ff,
+                dropout=t_cfg.dropout,
+                activation=t_cfg.hidden_activation,
+                rngs=rngs,
+            )
+            for _ in range(t_cfg.n_layers)
+        ]
+        self.decoder_norm = nnx.LayerNorm(num_features=d_model, rngs=rngs)
+        out_patch_dim = self.patch_size**2 * self.obs_shape[2]
+        self.out_proj = nnx.Linear(d_model, out_patch_dim, rngs=rngs)
+        self.n_patches = n_patches
 
     def __call__(self, x: jax.Array, *, return_cls_token: bool = False) -> jax.Array:
         """
@@ -351,59 +550,58 @@ class ViT(nnx.Module):
         Parameters
         ----------
         x : jax.Array
-            Input tensor of shape (B, H, W, C) in NHWC format.
+            Encoder mode: image tensor of shape ``(B, H, W, C)`` in NHWC format.
+            Decoder mode: CLS token of shape ``(B, d_model)`` or ``(B, 1, d_model)``.
         return_cls_token : bool
-            Whether to return CLS token only. Default is False.
+            Retained for backward compatibility; the encoder always returns the CLS token.
 
         Returns
         -------
         jax.Array
-            Output tensor.
+            Encoder mode: CLS token of shape ``(B, d_model)``.
+            Decoder mode: reconstructed image of shape ``(B, H, W, C)``.
         """
-        x = self.patch_embed(x) if self.is_encoder else self.patchify(x)
-        x = self.positional_encoding(x)
+        del return_cls_token
+        if self.is_encoder:
+            return self._forward_encoder(x)
+        return self._forward_decoder(x)
+
+    def _forward_encoder(self, x: jax.Array) -> jax.Array:
+        x = self.patch_embed(x)  # (B, N, d_model)
+        pos = jnp.broadcast_to(self._pos_emb.value, (x.shape[0], x.shape[1], x.shape[2]))
         if hasattr(self, "_cls_token"):
             cls_token = jnp.broadcast_to(self._cls_token.value, (x.shape[0], 1, x.shape[-1]))
+            cls_pos = jnp.broadcast_to(self._cls_pos_emb.value, (x.shape[0], 1, x.shape[-1]))
             x = jnp.concatenate([cls_token, x], axis=1)
-        x = self.vit(x)
+            pos = jnp.concatenate([cls_pos, pos], axis=1)
+        for block in self.encoder_blocks:
+            x = block(x, pos)
+        x = self.encoder_norm(x)
         if hasattr(self, "_cls_token"):
-            cls_token = x[:, 0]
-            x = x[:, 1:]
-        if self.should_unpatchify:
-            x = self.unpatchify(x)
-        if return_cls_token and hasattr(self, "_cls_token"):
-            return cls_token
-        return x
+            return x[:, 0]
+        return x.mean(axis=1)
+
+    def _forward_decoder(self, cls_token: jax.Array) -> jax.Array:
+        if cls_token.ndim == 2:
+            cls_token = cls_token[:, None, :]
+        memory = self.kv_proj(self.kv_norm(cls_token))  # (B, 1, d_model)
+        queries = jnp.broadcast_to(
+            self._queries.value,
+            (cls_token.shape[0], self.n_patches, self.d_model),
+        )
+        for block in self.decoder_blocks:
+            queries = block(queries, memory)
+        queries = self.decoder_norm(queries)
+        patches = self.out_proj(queries)  # (B, P, p*p*C)
+        return self.unpatchify(patches)
 
     def patchify(self, imgs: jax.Array) -> jax.Array:
-        """Split images into patches.
-
-        Parameters
-        ----------
-        imgs : jax.Array
-            Input images of shape (N, H, W, C) in NHWC format.
-
-        Returns
-        -------
-        jax.Array
-            Patchified images of shape (N, L, patch_size**2 * C).
-        """
+        """Split images into patches (NHWC)."""
         p = self.patch_size
         return rearrange(imgs, "n (h p1) (w p2) c -> n (h w) (p1 p2 c)", p1=p, p2=p)
 
     def unpatchify(self, x: jax.Array) -> jax.Array:
-        """Reconstruct images from patches.
-
-        Parameters
-        ----------
-        x : jax.Array
-            Input of shape (N, L, patch_size**2 * C).
-
-        Returns
-        -------
-        jax.Array
-            Images of shape (N, H, W, C) in NHWC format.
-        """
+        """Reconstruct images from patches (NHWC)."""
         p = self.patch_size
         h = self.obs_shape[0] // p
         w = self.obs_shape[1] // p
@@ -414,13 +612,12 @@ class ViT(nnx.Module):
 
     @property
     def conved_size(self) -> int:
-        """Get the flattened output size."""
-        return self.out_patch_dim * self.get_n_patches(self.in_shape)
+        """Get the CLS-token output size."""
+        return self.d_model
 
     @property
     def conved_shape(self) -> tuple[int, int]:
-        """Get the output shape after transformer."""
-        return (self.out_patch_dim, self.out_patch_dim)
+        return (1, 1)
 
     def get_n_patches(self, obs_shape: tuple[int, int, int]) -> int:
         """Get number of patches for a given shape (NHWC: H, W, C)."""
@@ -431,44 +628,10 @@ class ViT(nnx.Module):
         return self.patch_size**2 * obs_shape[2]
 
     @staticmethod
-    def get_input_shape(obs_shape: tuple[int, int, int], cfg: ViTConfig) -> tuple[int, int, int]:
-        """Get the required input shape (NHWC: H, W, C)."""
-        return (obs_shape[0], obs_shape[1], cfg.init_channel)
-
-
-class _ViTBlock(nnx.Module):
-    """Single ViT transformer block (pre-norm)."""
-
-    def __init__(
-        self,
-        dim: int,
-        num_heads: int,
-        mlp_hidden_dim: int,
-        *,
-        rngs: nnx.Rngs,
-    ) -> None:
-        self.norm1 = nnx.LayerNorm(num_features=dim, rngs=rngs)
-        self.attn = nnx.MultiHeadAttention(
-            num_heads=num_heads,
-            in_features=dim,
-            decode=False,
-            rngs=rngs,
-        )
-        self.norm2 = nnx.LayerNorm(num_features=dim, rngs=rngs)
-        self.fc1 = nnx.Linear(dim, mlp_hidden_dim, rngs=rngs)
-        self.fc2 = nnx.Linear(mlp_hidden_dim, dim, rngs=rngs)
-
-    def __call__(self, x: jax.Array) -> jax.Array:
-        # Self-attention with residual
-        h = self.norm1(x)
-        h = self.attn(h)
-        x = x + h
-        # MLP with residual
-        h = self.norm2(x)
-        h = self.fc1(h)
-        h = jax.nn.gelu(h)
-        h = self.fc2(h)
-        return x + h
+    def get_input_shape(obs_shape: tuple[int, int, int], cfg: ViTConfig) -> tuple[int, ...]:
+        """Input shape consumed by the ViT decoder: the CLS token has dimension ``d_model``."""
+        del obs_shape
+        return (cfg.transformer_cfg.d_model,)
 
 
 class ConvNet(nnx.Module):

--- a/src/ml_networks/torch/layers.py
+++ b/src/ml_networks/torch/layers.py
@@ -343,6 +343,7 @@ class MLPLayer(pl.LightningModule):
             layers += [LinearNormActivation(self.hidden_dim, self.hidden_dim, self.cfg.linear_cfg)]
         last_cfg = deepcopy(self.cfg.linear_cfg)
         last_cfg.activation = self.cfg.output_activation
+        last_cfg.norm = "none"
         layers += [LinearNormActivation(self.hidden_dim, self.output_dim, last_cfg)]
         return nn.Sequential(*layers)
 

--- a/src/ml_networks/torch/vision.py
+++ b/src/ml_networks/torch/vision.py
@@ -19,6 +19,7 @@ from ml_networks.config import (
     SpatialSoftmaxConfig,
     ViTConfig,
 )
+from ml_networks.torch.activations import Activation
 from ml_networks.torch.base import BaseModule
 from ml_networks.torch.layers import (
     Attention2d,
@@ -27,10 +28,8 @@ from ml_networks.torch.layers import (
     LinearNormActivation,
     MLPLayer,
     PatchEmbed,
-    PositionalEncoding,
     ResidualBlock,
     SpatialSoftmax,
-    TransformerLayer,
 )
 from ml_networks.utils import conv_out_shape, conv_transpose_in_shape, conv_transpose_out_shape
 
@@ -136,6 +135,8 @@ class Encoder(BaseModule):
         self.obs_shape = obs_shape
 
         self.encoder: nn.Module
+        self.fc: nn.Module
+        self._is_vit = isinstance(backbone_cfg, ViTConfig)
         if isinstance(backbone_cfg, ViTConfig):
             self.encoder = ViT(obs_shape, backbone_cfg)
         elif isinstance(backbone_cfg, ConvNetConfig):
@@ -147,6 +148,29 @@ class Encoder(BaseModule):
             raise NotImplementedError(msg)
 
         self.feature_dim = feature_dim
+
+        if self._is_vit:
+            # ViT encoder returns the CLS token (B, d_model); skip the convolutional reshape.
+            assert isinstance(backbone_cfg, ViTConfig)
+            d_model = backbone_cfg.transformer_cfg.d_model
+            self.last_channel = d_model
+            self.conved_shape = (1, 1)
+            self.conved_size = d_model
+            assert isinstance(feature_dim, int), "feature_dim must be int when using ViTConfig backbone"
+            if isinstance(fc_cfg, MLPConfig):
+                self.fc = MLPLayer(d_model, feature_dim, fc_cfg)
+            elif isinstance(fc_cfg, LinearConfig):
+                self.fc = LinearNormActivation(d_model, feature_dim, fc_cfg)
+            elif fc_cfg is None:
+                assert d_model == feature_dim, (
+                    f"feature_dim must equal transformer d_model when fc_cfg is None, got {feature_dim} vs {d_model}"
+                )
+                self.fc = nn.Identity()
+            else:
+                msg = f"fc_cfg type {type(fc_cfg)} is not supported with ViTConfig backbone"
+                raise NotImplementedError(msg)
+            return
+
         # 型情報を補うために明示的にキャスト
         self.conved_size = cast("int", self.encoder.conved_size)
         self.conved_shape = cast("tuple[int, int]", self.encoder.conved_shape)
@@ -158,7 +182,6 @@ class Encoder(BaseModule):
             assert feature_dim == (self.last_channel, *self.conved_shape), (
                 f"{feature_dim} != {(self.last_channel, *self.conved_shape)}"
             )
-        self.fc: nn.Module
         if isinstance(fc_cfg, MLPConfig):
             assert isinstance(feature_dim, int), "feature_dim must be int when using MLPConfig"
             self.fc = nn.Sequential(
@@ -254,8 +277,12 @@ class Encoder(BaseModule):
 
         x = x.reshape([-1, *self.obs_shape])
         x = self.encoder(x)
-        x = x.view(-1, self.last_channel, *self.conved_shape)
-        x = self.fc(x)
+        if self._is_vit:
+            # ViT encoder returns the CLS token (B, d_model); feed it directly into fc.
+            x = self.fc(x)
+        else:
+            x = x.view(-1, self.last_channel, *self.conved_shape)
+            x = self.fc(x)
         return x.reshape([*batch_shape, *x.shape[1:]])
 
 
@@ -377,45 +404,68 @@ class Decoder(BaseModule):
 
         self.obs_shape = obs_shape
         self.feature_dim = feature_dim
+        self._is_vit = isinstance(backbone_cfg, ViTConfig)
+        self.fc: nn.Module
+        self.input_shape: tuple[int, ...]
+        self.decoder: nn.Module
 
-        self.input_shape: tuple[int, int, int]
-        if isinstance(backbone_cfg, ViTConfig):
-            self.input_shape = ViT.get_input_shape(obs_shape, backbone_cfg)
-        elif isinstance(backbone_cfg, ConvNetConfig):
-            self.input_shape = cast(
+        if self._is_vit:
+            assert isinstance(backbone_cfg, ViTConfig)
+            d_model = backbone_cfg.transformer_cfg.d_model
+            assert isinstance(feature_dim, int), "feature_dim must be int when using ViTConfig backbone"
+            # ViT decoder consumes a CLS token (B, d_model); fc maps feature_dim -> d_model.
+            if isinstance(fc_cfg, MLPConfig):
+                self.fc = MLPLayer(feature_dim, d_model, fc_cfg)
+            elif isinstance(fc_cfg, LinearConfig):
+                self.fc = LinearNormActivation(feature_dim, d_model, fc_cfg)
+            elif fc_cfg is None:
+                assert feature_dim == d_model, (
+                    f"feature_dim must equal transformer d_model when fc_cfg is None, got {feature_dim} vs {d_model}"
+                )
+                self.fc = nn.Identity()
+            else:
+                msg = f"fc_cfg type {type(fc_cfg)} is not supported with ViTConfig backbone"
+                raise NotImplementedError(msg)
+            self.input_shape = (d_model,)
+            self.has_fc = True
+            self.decoder = ViT(in_shape=(d_model,), obs_shape=obs_shape, cfg=backbone_cfg)
+            return
+
+        in_shape3: tuple[int, int, int]
+        if isinstance(backbone_cfg, ConvNetConfig):
+            in_shape3 = cast(
                 "tuple[int, int, int]",
                 ConvTranspose.get_input_shape(obs_shape, backbone_cfg),
             )
         elif isinstance(backbone_cfg, ResNetConfig):
-            self.input_shape = cast(
+            in_shape3 = cast(
                 "tuple[int, int, int]",
                 ResNetPixShuffle.get_input_shape(obs_shape, backbone_cfg),
             )
         else:
             msg = f"{type(backbone_cfg)} is not implemented"
             raise NotImplementedError(msg)
+        self.input_shape = in_shape3
         if isinstance(feature_dim, int):
             assert fc_cfg is not None, "fc_cfg must be provided if feature_dim is provided"
             self.has_fc = True
         else:
-            assert feature_dim == self.input_shape, f"{feature_dim} != {self.input_shape}"
+            assert feature_dim == in_shape3, f"{feature_dim} != {in_shape3}"
             self.has_fc = False
 
         if isinstance(fc_cfg, MLPConfig):
             assert isinstance(feature_dim, int), "feature_dim must be int when using MLPConfig"
-            self.fc: nn.Module = MLPLayer(feature_dim, int(np.prod(self.input_shape)), fc_cfg)
+            self.fc = MLPLayer(feature_dim, int(np.prod(in_shape3)), fc_cfg)
         elif isinstance(fc_cfg, LinearConfig):
             assert isinstance(feature_dim, int), "feature_dim must be int when using LinearConfig"
-            self.fc = LinearNormActivation(feature_dim, int(np.prod(self.input_shape)), fc_cfg)
+            self.fc = LinearNormActivation(feature_dim, int(np.prod(in_shape3)), fc_cfg)
         else:
             self.fc = nn.Identity()
 
-        if isinstance(backbone_cfg, ViTConfig):
-            self.decoder: nn.Module = ViT(in_shape=self.input_shape, obs_shape=obs_shape, cfg=backbone_cfg)
-        elif isinstance(backbone_cfg, ConvNetConfig):
-            self.decoder = ConvTranspose(in_shape=self.input_shape, obs_shape=obs_shape, cfg=backbone_cfg)
+        if isinstance(backbone_cfg, ConvNetConfig):
+            self.decoder = ConvTranspose(in_shape=in_shape3, obs_shape=obs_shape, cfg=backbone_cfg)
         elif isinstance(backbone_cfg, ResNetConfig):
-            self.decoder = ResNetPixShuffle(in_shape=self.input_shape, obs_shape=obs_shape, cfg=backbone_cfg)
+            self.decoder = ResNetPixShuffle(in_shape=in_shape3, obs_shape=obs_shape, cfg=backbone_cfg)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -432,6 +482,13 @@ class Decoder(BaseModule):
             output tensor of shape (batch_size, *obs_shape)
 
         """
+        if self._is_vit:
+            batch_shape, data_shape = x.shape[:-1], x.shape[-1:]
+            x = x.reshape([-1, *data_shape])
+            x = self.fc(x)  # (B, d_model)
+            x = self.decoder(x)  # (B, *obs_shape)
+            return x.reshape([*batch_shape, *self.obs_shape])
+
         if self.has_fc:
             batch_shape, data_shape = x.shape[:-1], x.shape[-1:]
         else:
@@ -444,22 +501,108 @@ class Decoder(BaseModule):
         return x.reshape([*batch_shape, *self.obs_shape])
 
 
+class _ViTEncoderBlock(nn.Module):
+    """ViT encoder block (pre-norm). Positional embedding is added to query and key only.
+
+    Follows the DETR convention (https://github.com/gokul-pv/DetectionTransformer): at every
+    layer the spatial positional embedding is added to the query and key tensors of the
+    self-attention, while the value tensor is left unmodified.
+    """
+
+    def __init__(self, d_model: int, nhead: int, dim_ff: int, dropout: float, activation: str) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=d_model,
+            num_heads=nhead,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.norm2 = nn.LayerNorm(d_model)
+        self.linear1 = nn.Linear(d_model, dim_ff)
+        self.activation = Activation(activation)
+        self.linear2 = nn.Linear(dim_ff, d_model)
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, x: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
+        h = self.norm1(x)
+        q = k = h + pos
+        v = h
+        attn_out, _ = self.attn(q, k, v, need_weights=False)
+        x = x + self.dropout(attn_out)
+        h = self.norm2(x)
+        h = self.linear1(h)
+        h = self.activation(h)
+        h = self.dropout(h)
+        h = self.linear2(h)
+        return x + self.dropout(h)
+
+
+class _ViTDecoderBlock(nn.Module):
+    """ViT decoder block: cross-attention from learnable queries to the projected CLS token.
+
+    Pre-norm cross-attention where the queries are the learnable patch tokens and the
+    key/value come from the projected CLS representation, followed by a residual MLP block.
+    """
+
+    def __init__(self, d_model: int, nhead: int, dim_ff: int, dropout: float, activation: str) -> None:
+        super().__init__()
+        self.norm_q = nn.LayerNorm(d_model)
+        self.norm_kv = nn.LayerNorm(d_model)
+        self.cross_attn = nn.MultiheadAttention(
+            embed_dim=d_model,
+            num_heads=nhead,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.norm_mlp = nn.LayerNorm(d_model)
+        self.linear1 = nn.Linear(d_model, dim_ff)
+        self.activation = Activation(activation)
+        self.linear2 = nn.Linear(dim_ff, d_model)
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, queries: torch.Tensor, memory: torch.Tensor) -> torch.Tensor:
+        q = self.norm_q(queries)
+        kv = self.norm_kv(memory)
+        attn_out, _ = self.cross_attn(q, kv, kv, need_weights=False)
+        queries = queries + self.dropout(attn_out)
+        h = self.norm_mlp(queries)
+        h = self.linear1(h)
+        h = self.activation(h)
+        h = self.linear2(h)
+        return queries + self.dropout(h)
+
+
 class ViT(nn.Module):
     """
     Vision Transformer for Encoder and Decoder.
 
+    The encoder mode (``obs_shape is None``) follows the DETR convention: a learnable per-patch
+    positional embedding is added to the query and key tensors of every self-attention layer
+    (rather than being added once at the input). When ``cfg.cls_token`` is True a CLS token with
+    its own learnable positional embedding is prepended, and the forward pass returns the CLS
+    token of shape ``(B, d_model)``.
+
+    The decoder mode (``obs_shape is not None``) takes a CLS token of shape ``(B, d_model)`` or
+    ``(B, 1, d_model)`` and reconstructs an image. The CLS token is projected to a hidden
+    dimension and used as the key/value of cross-attention. A fixed set of
+    ``P = (H // p) * (W // p)`` learnable query tokens interacts with this representation
+    through several cross-attention layers with residual MLP blocks. Each query is then
+    linearly projected to ``p * p * C`` pixels and rearranged into a ``(B, C, H, W)`` image.
+
     Parameters
     ----------
-    in_shape: tuple[int, int, int]
-        shape of input tensor
-    cfg: ViTConfig
-        configuration of the network
-    obs_shape: tuple[int, int, int]
-        shape of output tensor. If None, it is considered as Encoder. Default is None.
+    in_shape : tuple[int, ...]
+        Encoder mode: image shape ``(C, H, W)``. Decoder mode: ``(d_model,)``; the CLS token is
+        the input.
+    cfg : ViTConfig
+        Network configuration.
+    obs_shape : tuple[int, int, int] | None
+        Output image shape for decoder mode. ``None`` selects encoder mode.
 
     Examples
     --------
-    >>> from ml_networks.layers import TransformerConfig
+    >>> from ml_networks.config import TransformerConfig
     >>> in_shape = (3, 64, 64)
     >>> cfg = ViTConfig(
     ...     patch_size=8,
@@ -468,23 +611,27 @@ class ViT(nn.Module):
     ...         d_model=64,
     ...         nhead=8,
     ...         dim_ff=256,
-    ...         n_layers=3,
+    ...         n_layers=2,
     ...         dropout=0.0,
-    ...         hidden_activation="ReLU",
-    ...         output_activation="ReLU"
+    ...         hidden_activation="GELU",
+    ...         output_activation="GELU",
     ...     ),
-    ...     init_channel=3
+    ...     init_channel=3,
     ... )
     >>> encoder = ViT(in_shape, cfg)
     >>> x = torch.randn(2, *in_shape)
-    >>> y = encoder(x)
+    >>> cls = encoder(x)
+    >>> cls.shape
+    torch.Size([2, 64])
+    >>> decoder = ViT(in_shape=(64,), cfg=cfg, obs_shape=(3, 64, 64))
+    >>> y = decoder(cls)
     >>> y.shape
-    torch.Size([2, 1, 64, 64])
+    torch.Size([2, 3, 64, 64])
     """
 
     def __init__(
         self,
-        in_shape: tuple[int, int, int],
+        in_shape: tuple[int, ...],
         cfg: ViTConfig,
         obs_shape: tuple[int, int, int] | None = None,
     ) -> None:
@@ -492,105 +639,146 @@ class ViT(nn.Module):
 
         self.in_shape = in_shape
         self.cfg = cfg
-        self.obs_shape = obs_shape if obs_shape is not None else in_shape
         self.patch_size = cfg.patch_size
-
         self.transformer_cfg = cfg.transformer_cfg
-        self.in_patch_dim = self.get_patch_dim(in_shape)
-        self.out_patch_dim = self.get_patch_dim(obs_shape) if obs_shape is not None else self.transformer_cfg.d_model
-        self.positional_embedding = PositionalEncoding(
-            self.in_patch_dim,
-            self.transformer_cfg.dropout,
-            max_len=self.get_n_patches(in_shape),
-        )
-        self.vit = TransformerLayer(
-            self.in_patch_dim,
-            self.out_patch_dim,
-            self.transformer_cfg,
-        )
         self.is_encoder = obs_shape is None
-        if self.is_encoder:
-            self.n_patches = self.get_n_patches(in_shape)
-            self.patch_embed = PatchEmbed(
-                emb_dim=self.in_patch_dim,
-                patch_size=self.patch_size,
-                obs_shape=in_shape,
-            )
-        self.should_unpatchify = cfg.unpatchify
-        if cfg.cls_token:
-            self.cls_token = nn.Parameter(torch.randn(1, 1, self.in_patch_dim))
-        self.last_channel = self.get_n_patches(in_shape)
+        self.obs_shape: tuple[int, int, int] = (
+            obs_shape if obs_shape is not None else cast("tuple[int, int, int]", in_shape)
+        )
 
-    def forward(
-        self,
-        x: torch.Tensor,
-        return_cls_token: bool = False,
-    ) -> torch.Tensor:
+        d_model = self.transformer_cfg.d_model
+        self.d_model = d_model
+
+        if self.is_encoder:
+            self._build_encoder()
+            self.last_channel = d_model
+            self.out_patch_dim = d_model
+        else:
+            self._build_decoder()
+            self.out_patch_dim = self.patch_size**2 * self.obs_shape[0]
+            self.last_channel = self.out_patch_dim
+
+    def _build_encoder(self) -> None:
+        cfg = self.cfg
+        t_cfg = self.transformer_cfg
+        d_model = self.d_model
+        assert len(self.in_shape) == 3, "Encoder mode requires in_shape=(C, H, W)"
+        in_shape3 = cast("tuple[int, int, int]", self.in_shape)
+        n_patches = self.get_n_patches(in_shape3)
+
+        self.patch_embed = PatchEmbed(
+            emb_dim=d_model,
+            patch_size=self.patch_size,
+            obs_shape=in_shape3,
+        )
+        # Learnable positional embedding added to query and key at every encoder layer.
+        self.pos_emb = nn.Parameter(torch.randn(1, n_patches, d_model) * 0.02)
+
+        if cfg.cls_token:
+            self.cls_token = nn.Parameter(torch.randn(1, 1, d_model) * 0.02)
+            self.cls_pos_emb = nn.Parameter(torch.randn(1, 1, d_model) * 0.02)
+
+        self.encoder_blocks = nn.ModuleList(
+            [
+                _ViTEncoderBlock(
+                    d_model=d_model,
+                    nhead=t_cfg.nhead,
+                    dim_ff=t_cfg.dim_ff,
+                    dropout=t_cfg.dropout,
+                    activation=t_cfg.hidden_activation,
+                )
+                for _ in range(t_cfg.n_layers)
+            ],
+        )
+        self.encoder_norm = nn.LayerNorm(d_model)
+        self.n_patches = n_patches
+
+    def _build_decoder(self) -> None:
+        t_cfg = self.transformer_cfg
+        d_model = self.d_model
+        n_patches = self.get_n_patches(self.obs_shape)
+
+        # Learnable patch queries (1, P, d_model). One query per output patch.
+        self.queries = nn.Parameter(torch.randn(1, n_patches, d_model) * 0.02)
+        # Project the CLS token to the hidden dimension used as K/V in cross-attention.
+        self.kv_norm = nn.LayerNorm(d_model)
+        self.kv_proj = nn.Linear(d_model, d_model)
+
+        self.decoder_blocks = nn.ModuleList(
+            [
+                _ViTDecoderBlock(
+                    d_model=d_model,
+                    nhead=t_cfg.nhead,
+                    dim_ff=t_cfg.dim_ff,
+                    dropout=t_cfg.dropout,
+                    activation=t_cfg.hidden_activation,
+                )
+                for _ in range(t_cfg.n_layers)
+            ],
+        )
+        self.decoder_norm = nn.LayerNorm(d_model)
+        out_patch_dim = self.patch_size**2 * self.obs_shape[0]
+        self.out_proj = nn.Linear(d_model, out_patch_dim)
+        self.n_patches = n_patches
+
+    def forward(self, x: torch.Tensor, return_cls_token: bool = False) -> torch.Tensor:
         """
         Forward pass.
 
         Parameters
         ----------
-        x: torch.Tensor
-            input tensor of shape (batch_size, *in_shape)
-        return_cls_token: bool
-            whether to return cls_token. Default is False.
+        x : torch.Tensor
+            Encoder mode: image of shape ``(B, C, H, W)``.
+            Decoder mode: CLS token of shape ``(B, d_model)`` or ``(B, 1, d_model)``.
+        return_cls_token : bool
+            Retained for backward compatibility; the encoder always returns the CLS token.
 
         Returns
         -------
         torch.Tensor
-            output tensor of shape (batch_size, *obs_shape)
-        torch.Tensor
-            cls_token of shape (batch_size, self.out_patch_dim) if return_cls_token
-
+            Encoder mode: CLS token of shape ``(B, d_model)``.
+            Decoder mode: reconstructed image of shape ``(B, C, H, W)``.
         """
-        x = self.patch_embed(x) if self.is_encoder else self.patchify(x)
-        x = self.positional_embedding(x)
+        del return_cls_token
+        if self.is_encoder:
+            return self._forward_encoder(x)
+        return self._forward_decoder(x)
+
+    def _forward_encoder(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.patch_embed(x)  # (B, N, d_model)
+        pos = self.pos_emb.expand(x.shape[0], -1, -1)
         if hasattr(self, "cls_token"):
-            cls_token = self.cls_token.expand(x.shape[0], -1, -1)
-            x = torch.cat([cls_token, x], dim=1)
-        x = self.vit(x)
+            cls = self.cls_token.expand(x.shape[0], -1, -1)
+            cls_pos = self.cls_pos_emb.expand(x.shape[0], -1, -1)
+            x = torch.cat([cls, x], dim=1)
+            pos = torch.cat([cls_pos, pos], dim=1)
+        for block in self.encoder_blocks:
+            x = block(x, pos)
+        x = self.encoder_norm(x)
         if hasattr(self, "cls_token"):
-            cls_token = x[:, 0]
-            x = x[:, 1:]
-        if self.should_unpatchify:
-            x = self.unpatchify(x)
-        if return_cls_token and hasattr(self, "cls_token"):
-            return cls_token
-        return x
+            return x[:, 0]
+        return x.mean(dim=1)
+
+    def _forward_decoder(self, cls_token: torch.Tensor) -> torch.Tensor:
+        if cls_token.dim() == 2:
+            cls_token = cls_token.unsqueeze(1)
+        memory = self.kv_proj(self.kv_norm(cls_token))  # (B, 1, d_model)
+        queries = self.queries.expand(cls_token.shape[0], -1, -1)
+        for block in self.decoder_blocks:
+            queries = block(queries, memory)
+        queries = self.decoder_norm(queries)
+        patches = self.out_proj(queries)
+        return self.unpatchify(patches)
 
     def patchify(self, imgs: torch.Tensor) -> torch.Tensor:
-        """
-        画像をパッチに分割する.
-
-        Parameters
-        ----------
-        imgs: torch.Tensor
-            入力画像. (N, C, H, W)
-
-        Returns
-        -------
-        torch.Tensor
-            パッチ化した画像. (N, L, patch_size**2 * D)
-        """
+        """画像をパッチに分割する."""
         p = self.patch_size
         assert imgs.shape[-1] % p == 0
         assert imgs.shape[-2] % p == 0
         return rearrange(imgs, "n c (h p1) (w p2) -> n (h w) (p1 p2 c)", p1=p, p2=p)
 
     def unpatchify(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        パッチを画像に戻す.
-
-        Parameters
-        ----------
-        x : torch.Tensor
-            入力. (N, L, patch_size**2 * D)
-
-        Returns
-        -------
-            画像. (N, C, H, W)
-        """
+        """パッチを画像に戻す."""
         p = self.patch_size
         h = self.obs_shape[1] // p
         w = self.obs_shape[2] // p
@@ -601,11 +789,11 @@ class ViT(nn.Module):
 
     @property
     def conved_size(self) -> int:
-        return self.out_patch_dim * self.get_n_patches(self.in_shape)
+        return self.d_model
 
     @property
     def conved_shape(self) -> tuple[int, int]:
-        return (self.out_patch_dim, self.out_patch_dim)
+        return (1, 1)
 
     def get_n_patches(self, obs_shape: tuple[int, int, int]) -> int:
         return (obs_shape[1] // self.patch_size) * (obs_shape[2] // self.patch_size)
@@ -614,8 +802,10 @@ class ViT(nn.Module):
         return self.patch_size**2 * obs_shape[0]
 
     @staticmethod
-    def get_input_shape(obs_shape: tuple[int, int, int], cfg: ViTConfig) -> tuple[int, int, int]:
-        return (cfg.init_channel, obs_shape[1], obs_shape[2])
+    def get_input_shape(obs_shape: tuple[int, int, int], cfg: ViTConfig) -> tuple[int, ...]:
+        """Input shape consumed by the ViT decoder: the CLS token has dimension ``d_model``."""
+        del obs_shape
+        return (cfg.transformer_cfg.d_model,)
 
 
 class ResNetPixUnshuffle(nn.Module):

--- a/src/ml_networks/torch/vision.py
+++ b/src/ml_networks/torch/vision.py
@@ -719,6 +719,7 @@ class ViT(nn.Module):
         self.decoder_norm = nn.LayerNorm(d_model)
         out_patch_dim = self.patch_size**2 * self.obs_shape[0]
         self.out_proj = nn.Linear(d_model, out_patch_dim)
+        self.output_activation = Activation(self.cfg.decoder_output_activation)
         self.n_patches = n_patches
 
     def forward(self, x: torch.Tensor, return_cls_token: bool = False) -> torch.Tensor:
@@ -767,7 +768,7 @@ class ViT(nn.Module):
         for block in self.decoder_blocks:
             queries = block(queries, memory)
         queries = self.decoder_norm(queries)
-        patches = self.out_proj(queries)
+        patches = self.output_activation(self.out_proj(queries))
         return self.unpatchify(patches)
 
     def patchify(self, imgs: torch.Tensor) -> torch.Tensor:

--- a/uv.lock
+++ b/uv.lock
@@ -1777,7 +1777,7 @@ wheels = [
 
 [[package]]
 name = "ml-networks"
-version = "0.2.0"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
This pull request updates the documentation to consistently use the `ml_networks.torch` submodule for all PyTorch-related imports and configuration targets. This change clarifies the codebase structure, making it explicit when PyTorch implementations are being used, and helps avoid confusion with other possible backends. The changes affect YAML configuration files, code snippets, and utility function imports across multiple documentation files.

The most important changes are:

**YAML Configuration Target Updates:**
* All `_target_` fields in YAML configuration examples now reference classes under `ml_networks.torch` (e.g., `ml_networks.torch.layers.MLPLayer`, `ml_networks.torch.vision.Encoder`, `ml_networks.torch.distributions.Distribution`, etc.), replacing previous references to the generic `ml_networks` or other submodules. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L40-R40) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L112-R113) [[3]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L33-R33) [[4]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L52-R52) [[5]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L118-R118) [[6]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L141-R141) [[7]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L249-R249) [[8]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L267-R267) [[9]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L294-R294) [[10]](diffhunk://#diff-023c7c86c00ee86886c3103175cfa10bb33602cebfaeb01f902937ffa7c998c2L19-R19) [[11]](diffhunk://#diff-023c7c86c00ee86886c3103175cfa10bb33602cebfaeb01f902937ffa7c998c2L133-R134) [[12]](diffhunk://#diff-9e4dfd4faa680b6ecb0c1946dacf3aaf99b56ed178cd9c496ff61fcf470126cdL19-R19) [[13]](diffhunk://#diff-9e4dfd4faa680b6ecb0c1946dacf3aaf99b56ed178cd9c496ff61fcf470126cdL139-R140) [[14]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L15-R15) [[15]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L114-R115) [[16]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L145-R146)

**Python Import Statement Updates:**
* All code examples now import PyTorch-specific classes and functions from `ml_networks.torch` (e.g., `from ml_networks.torch import MLPLayer, Encoder, Decoder, Distribution, focal_loss, charbonnier, Activation, get_optimizer, torch_fix_seed, gumbel_softmax`, etc.), rather than from the base `ml_networks` module. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L77-R78) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L162-R164) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L197-R200) [[4]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L232-R236) [[5]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L181-R181) [[6]](diffhunk://#diff-aced553d88f836a9ee7779d01bdc6ca682488c4f1c00920e41f635c3045f085aL31-R31) [[7]](diffhunk://#diff-023c7c86c00ee86886c3103175cfa10bb33602cebfaeb01f902937ffa7c998c2L70-R71) [[8]](diffhunk://#diff-633f4979c26fc62ba81c76ad6cc1bcdf7fdee1624950bea1692bff97a11076e8L97-R98) [[9]](diffhunk://#diff-633f4979c26fc62ba81c76ad6cc1bcdf7fdee1624950bea1692bff97a11076e8L184-R185) [[10]](diffhunk://#diff-633f4979c26fc62ba81c76ad6cc1bcdf7fdee1624950bea1692bff97a11076e8L202-R203) [[11]](diffhunk://#diff-9e4dfd4faa680b6ecb0c1946dacf3aaf99b56ed178cd9c496ff61fcf470126cdL69-R70) [[12]](diffhunk://#diff-9e4dfd4faa680b6ecb0c1946dacf3aaf99b56ed178cd9c496ff61fcf470126cdL233-R235) [[13]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL12-R12) [[14]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL28-R28) [[15]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL45-R45) [[16]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL61-R61) [[17]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL80-R80) [[18]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL94-R94) [[19]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L55-R56) [[20]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL15-R15) [[21]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL27-R27) [[22]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL41-R42) [[23]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL73-R74)

**Consistency and Clarity Improvements:**
* The documentation now clearly distinguishes between backend-agnostic configuration and PyTorch-specific usage, reducing ambiguity and potential errors for users following the guides. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L40-R40) [[2]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L33-R33) [[3]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L15-R15)

**Utility Function Import Updates:**
* Utility functions such as `focal_loss`, `charbonnier`, `kl_divergence`, `kl_balancing`, `Activation`, `get_optimizer`, `torch_fix_seed`, and `gumbel_softmax` are now imported from `ml_networks.torch`, ensuring users are using the correct implementations for PyTorch. [[1]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL12-R12) [[2]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL28-R28) [[3]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL45-R45) [[4]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL61-R61) [[5]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL80-R80) [[6]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL94-R94) [[7]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL15-R15) [[8]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL27-R27) [[9]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL41-R42) [[10]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL73-R74)

**Documentation Coverage:**
* These changes are applied throughout all relevant documentation files, including guides for configuration management, getting started, encoder/decoder/MLP usage, distributions, utilities, loss functions, and data I/O. [[1]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L40-R40) [[2]](diffhunk://#diff-c7aa37e254e4e6a7a33058f3049370949b8f58a22bb9a0936340425dcd1fadc7L33-R33) [[3]](diffhunk://#diff-aced553d88f836a9ee7779d01bdc6ca682488c4f1c00920e41f635c3045f085aL31-R31) [[4]](diffhunk://#diff-023c7c86c00ee86886c3103175cfa10bb33602cebfaeb01f902937ffa7c998c2L19-R19) [[5]](diffhunk://#diff-633f4979c26fc62ba81c76ad6cc1bcdf7fdee1624950bea1692bff97a11076e8L22-R22) [[6]](diffhunk://#diff-9e4dfd4faa680b6ecb0c1946dacf3aaf99b56ed178cd9c496ff61fcf470126cdL19-R19) [[7]](diffhunk://#diff-50fbd8f13ea679d88627d6d47a85262c893c27de0bace4e1f2c36f64eed4cc7aL12-R12) [[8]](diffhunk://#diff-465919837d00d62d449f651829fc3acc7166283f1209ace64f4fe95130979ab2L15-R15) [[9]](diffhunk://#diff-eb1abb5aa54df69955b47ea4cf40b4a82bc204de0e7896e3ecace2e3d9fa479dL15-R15)

These updates will help users avoid confusion and ensure they are using the intended PyTorch implementations throughout the documentation.